### PR TITLE
Dualstack S3 domain

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -91,15 +91,15 @@
 
 <p class="rteindent1">&bull;
        <a href="
-       https://s3.amazonaws.com/geoda/software/docs/Geoda_tour.pdf" target="_blank">Installing GeoDa and a Quick Tour of GeoDa's Functionality</a> </p>
+       https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/Geoda_tour.pdf" target="_blank">Installing GeoDa and a Quick Tour of GeoDa's Functionality</a> </p>
 
          &bull;
 	<a href="
-https://s3.amazonaws.com/geoda/software/docs/geoda_1.8_1.pdf" target="_blank">Overview, Getting Started, Geovisualization, Multivariate Exploratory Data Analysis</a></p>
+https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/geoda_1.8_1.pdf" target="_blank">Overview, Getting Started, Geovisualization, Multivariate Exploratory Data Analysis</a></p>
 
-	&bull; <a href="https://s3.amazonaws.com/geoda/software/docs/geoda_1.8_2.pdf" target="_blank">Spatial Weights, Spatial Autocorrelation, Space-Time Exploration, Averages Tool, Spatial Regression</a></p>
+	&bull; <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/geoda_1.8_2.pdf" target="_blank">Spatial Weights, Spatial Autocorrelation, Space-Time Exploration, Averages Tool, Spatial Regression</a></p>
 
-	&bull; On local multivariate cluster functionality (new as of GeoDa 1.10). <a href="https://s3.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">Luc Anselin. (2017). A Local Indicator of Multivariate Spatial Association: Extending Geary's c. Working Paper: Center for Spatial Data Science, University of Chicago.(forthcoming, Geographical Analysis)</a></p>
+	&bull; On local multivariate cluster functionality (new as of GeoDa 1.10). <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">Luc Anselin. (2017). A Local Indicator of Multivariate Spatial Association: Extending Geary's c. Working Paper: Center for Spatial Data Science, University of Chicago.(forthcoming, Geographical Analysis)</a></p>
 
 	&bull; Non-spatial cluster functionality (new as of GeoDa 1.10). <a href="http://bonsai.hgc.jp/~mdehoon/software/cluster/cluster.pdf" target="_blank">Hoon, Michiel de, Seiya Imoto, Satoru Miyano. (2013). The C Clustering Library. The University of Tokyo, Institute of Medical Science, Human Genome Center.</a></p>
 
@@ -123,15 +123,15 @@ https://s3.amazonaws.com/geoda/software/docs/geoda_1.8_1.pdf" target="_blank">Ov
 
 <h3>Older Resources (2003-05)- Legacy GeoDa 0.95i</h3>
 
-<p>This workbook (2005) and the two documentation reports (2003) were developed for the Legacy version of GeoDa (0.9.5i) and is still useful for understanding the main functionality. However, many of the screenshots and menu options have been updated since. Here is a <a href="https://s3.amazonaws.com/geoda/software/docs/GeoDa1.8_toolbar.pdf">1-page overview</a> of GeoDa 1.8&#39;s functionality with references to the workbook chapters.</p>
+<p>This workbook (2005) and the two documentation reports (2003) were developed for the Legacy version of GeoDa (0.9.5i) and is still useful for understanding the main functionality. However, many of the screenshots and menu options have been updated since. Here is a <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/GeoDa1.8_toolbar.pdf">1-page overview</a> of GeoDa 1.8&#39;s functionality with references to the workbook chapters.</p>
 
 <p class="rteindent1">&bull;
-<a href="https://s3.amazonaws.com/geoda/software/docs/geodaworkbook.pdf" target="_blank" title="geodaworkbook.pdf">Exploring Spatial Data with GeoDa: A Workbook</a> (2005; 244 pp.,5.1Mb)</p>
+<a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/geodaworkbook.pdf" target="_blank" title="geodaworkbook.pdf">Exploring Spatial Data with GeoDa: A Workbook</a> (2005; 244 pp.,5.1Mb)</p>
 </ul>
 
 <p class="rteindent1">&bull;
-<a href="https://s3.amazonaws.com/geoda/software/docs/geoda093.pdf" target="_blank">GeoDa 0.9.3 User's Guide with overview of features</a> (2003; 125 pp., 2.4Mb)</br>
-&bull;  <a href="https://s3.amazonaws.com/geoda/software/docs/geoda095i.pdf">GeoDa 0.9.5-i Release Notes with overview of 3D scatter plot, conditional plots, and spatial regression</a>&nbsp;(2003; 64 pp., 1.5Mb)</p>
+<a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/geoda093.pdf" target="_blank">GeoDa 0.9.3 User's Guide with overview of features</a> (2003; 125 pp., 2.4Mb)</br>
+&bull;  <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/geoda095i.pdf">GeoDa 0.9.5-i Release Notes with overview of 3D scatter plot, conditional plots, and spatial regression</a>&nbsp;(2003; 64 pp., 1.5Mb)</p>
 
 <br />
 

--- a/index-cn.html
+++ b/index-cn.html
@@ -160,7 +160,7 @@ GeoDa支持更多的空间数据格式</h3>
 <br/>
 <h3>
 <a id="intro-diff-mi" class="anchor" href="#intro-diff-mi" aria-hidden="true"><span class="octicon octicon-link"></span></a>单/多变量的空间聚类分析</h3>
-<p><a href="https://s3.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">Luc Anselin (2017)</a> recently extended Geary's c with a new local indicator of spatial association. This is applied to the classic data set of "moral statistics" of France (Guerry, 1833) to show significant high and low spatial concentrations of literacy (left map) and significant associations of property crime and literacy (right map).</p>
+<p><a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">Luc Anselin (2017)</a> recently extended Geary's c with a new local indicator of spatial association. This is applied to the classic data set of "moral statistics" of France (Guerry, 1833) to show significant high and low spatial concentrations of literacy (left map) and significant associations of property crime and literacy (right map).</p>
 <p><img src="images/localGeary.png" class="shadowfilter"></p>
 
 <br/>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <p>Since its initial release in February 2003, GeoDa's user numbers have increased exponentially to over 300,000 (August 2019). This includes lab users at universities such as Harvard, MIT, and Cornell. The user community and press embraced the program enthusiastically, calling it a "hugely important analytic tool," a "very fine piece of software," and an "exciting development."</p>
 
-<p>The latest version 1.14 contains multi-layer support, several new local cluster features, including <a href="https://s3.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">univariate and multivariate local Geary cluster maps</a>, redcap, skater, spectral clustering and max-p, and local join count maps for categorical data. It also implements several classic non-spatial cluster techniques (principal component analysis, k-means, and hierarchical clustering) implemented in <a href="http://bonsai.hgc.jp/~mdehoon/software/cluster/cluster.pdf" target="_blank">Hoon et al.'s (2013) C Clustering Library</a>, as well as HDBScan.</p>
+<p>The latest version 1.14 contains multi-layer support, several new local cluster features, including <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">univariate and multivariate local Geary cluster maps</a>, redcap, skater, spectral clustering and max-p, and local join count maps for categorical data. It also implements several classic non-spatial cluster techniques (principal component analysis, k-means, and hierarchical clustering) implemented in <a href="http://bonsai.hgc.jp/~mdehoon/software/cluster/cluster.pdf" target="_blank">Hoon et al.'s (2013) C Clustering Library</a>, as well as HDBScan.</p>
 
 <p>A new workbook is under development. In the meantime, <a href="documentation.html"  onclick="ga('send', 'event', 'GeoDaTutorial18O', 'GeoDaDocument', 'GeoDa Tutorial 18');">here are interim resources</a>, including an overview of features in 1.14.</p>
 
@@ -173,7 +173,7 @@ makeBSS('.num2', opts);
 <br/>
 <h3>
 <a id="intro-diff-mi" class="anchor" href="#intro-diff-mi" aria-hidden="true"><span class="octicon octicon-link"></span></a>Test if Multiple Variables Are Clustered in Space</h3>
-<p><a href="https://s3.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">Luc Anselin (2017)</a> recently extended Geary's c with a new local indicator of spatial association. This is applied to the classic data set of "moral statistics" of France (Guerry, 1833) to show significant high and low spatial concentrations of literacy (left map) and significant associations of property crime and literacy (right map).</p>
+<p><a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/docs/LA_multivariateGeary1.pdf" target="_blank">Luc Anselin (2017)</a> recently extended Geary's c with a new local indicator of spatial association. This is applied to the classic data set of "moral statistics" of France (Guerry, 1833) to show significant high and low spatial concentrations of literacy (left map) and significant associations of property crime and literacy (right map).</p>
 <p><img src="images/localGeary.png" class="shadowfilter"></p>
 
 <br/>

--- a/questions.html
+++ b/questions.html
@@ -110,7 +110,7 @@
 
 <h2><a name="isle">What to do with islands?</a></h2>
 <p>Islands should not be used for LISA maps and can be problematic for GeoDa&#39;s regression models. One option to ensure no islands is to use distance weights (distance bands or k-nearest neighbors). You can also remove islands in GeoDa by exporting a new spatial file without islands or by assigning them to other areas that are similar by editing the weights matrix in a text editor (for details on the weights formats, see the <a href="
-https://s3.amazonaws.com/geoda/software/docs/geoda093.pdf" target="_self">GeoDa 0.9.3 User&#39;s Guide</a>, pp. 80-81). You will need to assign a mainland area ID to the island ID, and vice versa, assign the island ID to the mainland ID.</p>
+https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/geoda093.pdf" target="_self">GeoDa 0.9.3 User&#39;s Guide</a>, pp. 80-81). You will need to assign a mainland area ID to the island ID, and vice versa, assign the island ID to the mainland ID.</p>
 
 <h2><a name="projection">How do I assign projections and coordinate systems to my spatial file?</a></h2>
 <p>GeoDa does not contain any tools to set or change map projections or geographic coordinate systems. Geographic coordinate systems are relevant for adding a basemap to your map (you need WGS84). They can be relevant when using GeoDa&#39;s distance weights, which are based on the distances between points. You can set the distance units displayed in the weights distance dialog (e.g., feet, meters, or miles) by first projecting the spatial file in a <a href="glossary.html#gis">GIS</a> outside of GeoDa.
@@ -136,7 +136,7 @@ https://s3.amazonaws.com/geoda/software/docs/geoda093.pdf" target="_self">GeoDa 
 <p>You can access GeoDa&#39;s regression functionality without opening a spatial file by going directly to Regress after opening GeoDa. This option is particularly useful if you are working with large datasets (e.g., several hundred thousand observations), to avoid loading times of the map file.</p>
 
 <h2><a name="output">Where can I get help interpreting the regression output?</a></h2>
-<p>The <a href="https://s3.amazonaws.com/geoda/software/docs/geodaworkbook.pdf" target="_self">GeoDa workbook</a> contains several regression chapters with more detail on interpretation of output. For further background reading, see the <a href="https://spatial.uchicago.edu/spatial-analysis-references>regression references</a> and, in particular, Anselin (1988)</a>.</p>
+<p>The <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/geodaworkbook.pdf" target="_self">GeoDa workbook</a> contains several regression chapters with more detail on interpretation of output. For further background reading, see the <a href="https://spatial.uchicago.edu/spatial-analysis-references>regression references</a> and, in particular, Anselin (1988)</a>.</p>
 
 
 <h3>

--- a/refs.html
+++ b/refs.html
@@ -53,7 +53,7 @@
 <p>Worboys, M.F. and Duckham, M. (2004). <i>GIS: A Computing Perspective.</i> 2nd edition. CRC Press.</p>
 <ul></ul>
 <h2><a name="smooth"></a><a name="smoothf">Smoothing, Standardization, and Excess Risk</a></h2>
-<p>Anselin, L., Y. W. Kim and I. Syabri. <a href="https://s3.amazonaws.com/geoda/software/docs/webtools2.pdf">Web-Based Analytical Tools for the Exploration of Spatial Data</a><i> Journal of Geographical Systems</i> (forthcoming). For more details on EB smoother, also see Bailey, T.C. and Gatrell, A. C. (1995). Interactive Spatial Data Analysis. John Wiley and Sons, New York, NY (pp. 303-308).</p>
+<p>Anselin, L., Y. W. Kim and I. Syabri. <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/webtools2.pdf">Web-Based Analytical Tools for the Exploration of Spatial Data</a><i> Journal of Geographical Systems</i> (forthcoming). For more details on EB smoother, also see Bailey, T.C. and Gatrell, A. C. (1995). Interactive Spatial Data Analysis. John Wiley and Sons, New York, NY (pp. 303-308).</p>
 <p>Although these references do not refer to the spatial EB smoother, it is computed the same way as the regular EB smoother except that the mean and variance of the prior are taken from a local subset (as defined by the weights) rather than the study region as a whole.</p>
 <p>Assuncao, R. and Reis, E. A. (1999). A new proposal to adjust Moran?s I for population density. <i>Statistics in Medicine,</i> 18:2147-2161.</p>
 <ul>Empirical Bayes Smoothing and Excess Risk Empirical Bayes Standardization</ul>
@@ -68,7 +68,7 @@
 <p>Smirnov, O. and Anselin, L. (2001). Fast maximum likelihood estimation of very large spatial autoregressive models: A characteristic polynomial approach. <i>Computational Statistics and Data Analysis</i>, 35:301-319.</p>
 <ul></ul>
 <h2><a name="thiessenf">Thiessen Polygons</a></h2>
-<p><a href="http://www.cs.sunysb.edu/~algorith/implement/ANN/implement.shtml">Mount, D. and S. Arya. <i>ANN Approximate Nearest Neighbors</i></a> (Version 0.2; 1998). See Appendix B - ANN License Agreement of the <a href="https://s3.amazonaws.com/geoda/software/docs/docs/geoda093.pdf" target="_self">GeoDa 0.9.3 User&#39;s Guide</a>.</p>
+<p><a href="http://www.cs.sunysb.edu/~algorith/implement/ANN/implement.shtml">Mount, D. and S. Arya. <i>ANN Approximate Nearest Neighbors</i></a> (Version 0.2; 1998). See Appendix B - ANN License Agreement of the <a href="https://s3.dualstack.us-east-1.amazonaws.com/geoda/software/docs/docs/geoda093.pdf" target="_self">GeoDa 0.9.3 User&#39;s Guide</a>.</p>
 
 
       <footer class="site-footer">

--- a/updates/README
+++ b/updates/README
@@ -5,11 +5,11 @@ For Mac Users, all upgrade to 1.8.16 will be made through
 checklist.macosx.txt
 
 After upgrade to 1.8.16, MacOSX10.6 users will check 
-https://s3.amazonaws.com/geodaupdate/checklist.macosx106.txt
+https://s3.dualstack.us-east-1.amazonaws.com/geodaupdate/checklist.macosx106.txt
 for upgrade.
 
 After upgrade to 1.8.16, MacOSX10.7+ users will check
-https://s3.amazonaws.com/geodaupdate/checklist.macosx107.txt
+https://s3.dualstack.us-east-1.amazonaws.com/geodaupdate/checklist.macosx107.txt
 for upgrade.
 
 1.8.16.2 with retina support will be available for MacOSX10.7+ users for upgrade.
@@ -20,8 +20,8 @@ For Windows Users, all upgrade to 1.8.16 will be made through
 checklist.win32.txt and checklist.win64.txt.
 
 After upgrade to 1.8.16, all Windows users will check
-https://s3.amazonaws.com/geodaupdate/checklist.win32.txt
-https://s3.amazonaws.com/geodaupdate/checklist.win64.txt
+https://s3.dualstack.us-east-1.amazonaws.com/geodaupdate/checklist.win32.txt
+https://s3.dualstack.us-east-1.amazonaws.com/geodaupdate/checklist.win64.txt
 for upgrade.
 
 The new checklist file will add one line (3rd line) as download message, which will be shown on the auto-upgrade dialog


### PR DESCRIPTION
Replaced `s3.amazonaws.com` with `s3.dualstack.us-east-1.amazonaws.com`, which adds IPv6 support.